### PR TITLE
Removed dependeny on oteapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ requires-python = "~=3.9"
 dynamic = ["version"]
 
 dependencies = [
-    "Dlite-Python>=0.5.0<0.6",
+    "Dlite-Python>=0.4.5,<0.6",
     "simphony-osp ~=4.0",
-    "tripper>=0.2.0<0.3"
+    "tripper>=0.2.0,<0.3"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,9 @@ requires-python = "~=3.9"
 dynamic = ["version"]
 
 dependencies = [
-    "Dlite-Python",
+    "Dlite-Python>=0.5.0<0.6",
     "simphony-osp ~=4.0",
+    "tripper>=0.2.0<0.3"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ dynamic = ["version"]
 dependencies = [
     "Dlite-Python",
     "simphony-osp ~=4.0",
-    "oteapi-core ==0.5.2",
-    "tripper ~=0.2.13",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cuds2dlite_create_instance.py
+++ b/tests/test_cuds2dlite_create_instance.py
@@ -60,7 +60,7 @@ def test_cuds2dlite_simphony_create_instances(repo_dir):
     assert labels == ["6ce00d67-46dc-404f-901b-41d17ba7b0a0"]
     # Check that only the one instance is present
     coll.get("6ce00d67-46dc-404f-901b-41d17ba7b0a0")
-    with pytest.raises(dlite.DLiteUnknownError):
+    with pytest.raises(dlite.DLiteValueError):
         coll.get("3919ea39-4c00-44f6-a8d2-affc09a78111")
 
     # Check that the relations are still correct.


### PR DESCRIPTION
There are currently no oteapi-strategies so this dependency does not make sense.
This will have to be added again if or when oteapi-strategies are included.